### PR TITLE
Polaris Web Components Context MCP Tools

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,7 +2,9 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { searchShopifyAdminSchema } from "./shopify-admin-schema.js";
 
-const SHOPIFY_BASE_URL = "https://shopify.dev";
+const SHOPIFY_BASE_URL = process.env.DEV
+  ? "https://shopify-dev.myshopify.io/"
+  : "https://shopify.dev/";
 
 /**
  * Searches Shopify documentation with the given query
@@ -152,4 +154,109 @@ export function shopifyTools(server: McpServer) {
       };
     },
   );
+
+  if (process.env.POLARIS_UNIFIED) {
+    server.tool(
+      "read_polaris_surface_docs",
+      `Use this tool to retrieve a list of documents from shopify.dev.
+
+      Args:
+      paths: The paths to the documents to read, in a comma separated list.
+      Paths should be relative to the root of the developer documentation site.`,
+      {
+        paths: z
+          .array(z.string())
+          .describe("The paths to the documents to read"),
+      },
+      async ({ paths }) => {
+        async function fetchDocText(path: string): Promise<{
+          text: string;
+          path: string;
+          success: boolean;
+        }> {
+          try {
+            const appendedPath = path.endsWith(".txt") ? path : `${path}.txt`;
+            const url = new URL(appendedPath, SHOPIFY_BASE_URL);
+            const response = await fetch(url.toString());
+            const text = await response.text();
+            return { text: `## ${path}\n\n${text}\n\n`, path, success: true };
+          } catch (error) {
+            return {
+              text: `Error fetching document at ${path}: ${error}`,
+              path,
+              success: false,
+            };
+          }
+        }
+
+        const fetchDocs = paths.map((path) => fetchDocText(path));
+        const results = await Promise.all(fetchDocs);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: results.map(({ text }) => text).join("---\n\n"),
+            },
+          ],
+        };
+      },
+    );
+
+    const surfaces = [
+      "app-home",
+      "admin-extensions",
+      "checkout-extensions",
+      "customer-account-extensions",
+    ] as const;
+    server.tool(
+      "get_started",
+      `
+      1. Ask user for the surface they are building for.
+      2. Use read_polaris_surface_docs tool to read the docs for the surface.
+
+      Whenever the user asks about Polaris web components, always use this tool first to provide the most accurate and up-to-date documentation.
+
+      valid arguments for this tool are:
+      - "app-home"
+      - "admin-extensions"
+      - "checkout-extensions"
+      - "customer-account-extensions"
+
+      Once you determine the surface, you should then use the read_polaris_surface_docs tool to learn about more specific details. Overviews are not comprehensive, so this is important.
+
+      DON'T SEARCH THE WEB WHEN REFERENCING INFORMATION FROM THIS DOCUMENTATION. IT WILL NOT BE ACCURATE. ONLY USE THE read_polaris_surface_docs TOOLS TO RETRIEVE INFORMATION FROM THE DEVELOPER DOCUMENTATION SITE.
+    `,
+      {
+        surface: z
+          .enum(surfaces)
+          .describe("The Shopify surface you are building for"),
+      },
+      async function cb({ surface }) {
+        if (!surfaces.includes(surface)) {
+          const options = surfaces.map((s) => `- ${s}`).join("\n");
+          const text = `Please specify which Shopify surface you are building for. Valid options are: ${options}.`;
+
+          return {
+            content: [{ type: "text" as const, text }],
+          };
+        }
+
+        const docEntrypointsBySurface: Record<string, string> = {
+          "app-home": "/docs/api/app-home/using-polaris-components",
+          "admin-extensions": "/docs/api/admin-extensions",
+          "checkout-extensions": "/docs/api/checkout-ui-extensions",
+          "customer-account-extensions":
+            "/docs/api/customer-account-ui-extensions",
+        };
+
+        const docPath = docEntrypointsBySurface[surface];
+        const text = await fetchDocText(docPath);
+
+        return {
+          content: [{ type: "text" as const, text }],
+        };
+      },
+    );
+  }
 }


### PR DESCRIPTION
## TLDR

Polaris Web Components Context MCP Tools

Closes https://github.com/Shopify/admin-ui-foundations/issues/2813

## More Context

- Add the following MCP tools behind the `POLARIS_UNIFIED` env var.
   - `get_started`
   - `read_docs`
   
## Tophatting Instructions

1. In the `dev-mcp` repo, checkout the `bf/mcp-mob-pairing` branch and install dependencies
   ```shell
   dev cd dev-mcp && git checkout bf/mcp-mob-pairing && npm i
   ```
1. In the `dev-mcp` repo, start the inspector
      ```shell
      npm run inspector
      ```

### Inspector

1. In your browser, navigate to http://localhost:5173 to access the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector). 
1. Click **Connect**
1. Click **Tools**
1. Click **List Tools**
1. Confirm presence/absence of `get_started` and `read_docs` tools
   - 👀 When the `POLARIS_UI=true` env var is present, `get_started` and `read_docs` should be present.    
   ![image](https://github.com/user-attachments/assets/5607d5ff-871c-4edf-b97d-002b7d539ac2)
   - 🙈 When the `POLARIS_UI=true` env var is absent, the `get_started` and `read_docs` should be absent. 
   ![image](https://github.com/user-attachments/assets/6c487e54-20a5-47f8-affb-af628dda6c3d)

### Cursor 

1. In your terminal, get the absolute path to the version of node you'd like to use. 
   ```shell
   which node
   ```
   - Depending on your node env, this might not be necessary. In my case, Cursor couldn't find my node env. 
1. In Cursor, open [Cursor Settings](https://docs.cursor.com/guides/migration/vscode#settings-menus)
1. In Cursor, click **MCP Servers**
1. In Cursor, click **Add new global MCP server**
1. In `.cursor/mcp.json`, add the following following JSON
   ```js
   "shopify-dev-mcp-local": {
      "command": "${ABSOLUTE_PATH_TO_NODE} ${PATH_TO_DEV_MCP_PARENT_FOLDER}/dev-mcp/dist/index.js",
      // For example: "command": "/opt/dev/sh/nvm/versions/node/v22.15.0/bin/node /Users/bill/src/github.com/Shopify/dev-mcp/dist/index.js",
      "env": {
        "POLARIS_UI": "true"
      }
    }
   ```
1. Close `mcp.json`
1. In Cursor Settings > MCP Servers, confirm that `shopify-dev-mcp-local` is present and connected
1. Confirm presence/absence of `get_started` and `read_docs` tools
   - 👀 When the `POLARIS_UI=true` env var is present, `get_started` and `read_docs` should be present.    
      - <img width="1512" alt="image" src="https://github.com/user-attachments/assets/4047e191-e4c8-492d-9b49-26de06737240" />
   - 🙈 When the `POLARIS_UI=true` env var is absent, the `get_started` and `read_docs` should be absent. 
      - <img width="1512" alt="image" src="https://github.com/user-attachments/assets/b531f7be-46ba-4355-aa04-84e0f1c95af5" />


> [!IMPORTANT]
> If the `dev-mcp` build changes, then you'll need to click the **Refresh** button in Cursor Settings > MCP Servers to get the changes. 

https://github.com/user-attachments/assets/7cddb0cb-9435-41df-845a-deec10418ff1
   
## Demo

https://share.descript.com/view/oIyIXvuwZkr

## References

- https://docs.cursor.com/context/model-context-protocol#configuring-mcp-servers