### PR TITLE
Use native ESM conventions to determine SCHEMA_FILE_PATH

### DIFF
--- a/src/tools/shopify-admin-schema.ts
+++ b/src/tools/shopify-admin-schema.ts
@@ -1,21 +1,12 @@
-import fs from "fs/promises";
-import path from "path";
-import { fileURLToPath } from "url";
-import zlib from "zlib";
-import { existsSync } from "fs";
-
-// Get the directory name for the current module
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
+import zlib from "node:zlib";
 
 // Path to the schema file in the data folder
-export const SCHEMA_FILE_PATH = path.join(
-  __dirname,
-  "..",
-  "..",
-  "data",
-  "admin_schema_2025-01.json",
-);
+export const SCHEMA_FILE_PATH = new URL(
+  "../../data/admin_schema_2025-01.json",
+  import.meta.url,
+).pathname;
 
 // Function to load schema content, handling decompression if needed
 export async function loadSchemaContent(schemaPath: string): Promise<string> {

--- a/src/tools/shopify-admin-schema.ts
+++ b/src/tools/shopify-admin-schema.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import zlib from "node:zlib";
 
 // Path to the schema file in the data folder
-export const SCHEMA_FILE_PATH = new URL(
-  "../../data/admin_schema_2025-01.json",
-  import.meta.url,
-).pathname;
+export const SCHEMA_FILE_PATH = fileURLToPath(
+  new URL("../../data/admin_schema_2025-01.json", import.meta.url),
+);
 
 // Function to load schema content, handling decompression if needed
 export async function loadSchemaContent(schemaPath: string): Promise<string> {


### PR DESCRIPTION
This pull request refactors the `src/tools/shopify-admin-schema.ts` file to replace `path`-based file path construction with `URL` for better compatibility with ES modules.

* Replaced the use of `path` and `__dirname` for constructing file paths with `URL` to leverage native ES module features and simplify the code. (`[src/tools/shopify-admin-schema.tsL1-R9](diffhunk://#diff-86eb45fded7c47cd422cba1cc0866d3c4afc86424bf1e1f5d959f554cb1613a2L1-R9)`)