### PR TITLE
Replace `SHOPIFY_GH_ACCESS_TOKEN` with `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v3
         name: Setup node.js
@@ -27,7 +27,7 @@ jobs:
       - name: Create snapshot
         uses: Shopify/snapit@main
         env:
-          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           build_script: npm run build


### PR DESCRIPTION
>Error: Input required and not supplied: token - https://github.com/Shopify/dev-mcp/actions/runs/15053510636/job/42313792509
