### PR TITLE
Add GraphQL validation tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.1",
+        "graphql": "^16.11.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -5036,6 +5037,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "description": "A command line tool for setting up Shopify Dev MCP server",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
+    "graphql": "^16.11.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -257,6 +257,8 @@ export async function shopifyTools(server: McpServer): Promise<void> {
     "search_dev_docs",
     `This tool will take in the user prompt, search shopify.dev, and return relevant documentation and code examples that will help answer the user's question.
 
+    YOU MUST CALL THIS TOOL AT LEAST ONCE FOR A SHOPIFY RELATED QUESTION TO CHECK IF THE DOCUMENTATION HAS ANY EXAMPLES AVAILABLE.
+
     It takes one argument: prompt, which is the search query for Shopify documentation.`,
     {
       prompt: z.string().describe("The search query for Shopify documentation"),
@@ -341,6 +343,8 @@ export async function shopifyTools(server: McpServer): Promise<void> {
     "get_started",
     `
     YOU MUST CALL THIS TOOL FIRST WHENEVER YOU ARE IN A SHOPIFY APP AND THE USER WANTS TO LEARN OR INTERACT WITH ANY OF THESE APIS:
+
+    YOU MUST CALL THIS TOOL FIRST WHEN YOU ARE IN A SHOPIFY APP OR THE USER WANTS TO LEARN OR INTERACT WITH ANY OF THESE APIS:
 
     Valid arguments for \`api\` are:
 ${gettingStartedApis.map((api) => `    - ${api.name}: ${api.description}`).join("\n")}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -346,9 +346,7 @@ export async function shopifyTools(server: McpServer): Promise<void> {
   server.tool(
     "get_started",
     `
-    YOU MUST CALL THIS TOOL FIRST WHENEVER YOU ARE IN A SHOPIFY APP AND THE USER WANTS TO LEARN OR INTERACT WITH ANY OF THESE APIS:
-
-    YOU MUST CALL THIS TOOL FIRST WHEN YOU ARE IN A SHOPIFY APP OR THE USER WANTS TO LEARN OR INTERACT WITH ANY OF THESE APIS:
+    YOU MUST CALL THIS TOOL FIRST WHENEVER YOU ARE IN A SHOPIFY APP AND/OR THE USER WANTS TO LEARN OR INTERACT WITH ANY OF THESE APIS:
 
     Valid arguments for \`api\` are:
 ${gettingStartedApis.map((api) => `    - ${api.name}: ${api.description}`).join("\n")}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -371,7 +371,10 @@ ${gettingStartedApis.map((api) => `    - ${api.name}: ${api.description}`).join(
 
       try {
         const response = await fetch(
-          `${SHOPIFY_BASE_URL}/mcp/getting_started?api=${api}`,
+          new URL(
+            `/mcp/getting_started?api=${api}`,
+            SHOPIFY_BASE_URL,
+          ).toString(),
         );
 
         if (!response.ok) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -242,6 +242,10 @@ export async function shopifyTools(server: McpServer): Promise<void> {
     async ({ code }) => {
       const result = await validateShopifyGraphQL(code);
 
+      recordUsage("validate_graphql", code, result.formattedText).catch(
+        () => {},
+      );
+
       return {
         content: [
           {

--- a/src/tools/shopify-admin-schema.ts
+++ b/src/tools/shopify-admin-schema.ts
@@ -141,6 +141,23 @@ export const formatSchemaType = (item: any): string => {
       } more input fields`;
     }
   }
+  // For ENUM types, list enum values
+  else if (
+    item.kind === "ENUM" &&
+    item.enumValues &&
+    item.enumValues.length > 0
+  ) {
+    result += "\n  Enum Values:";
+    for (const value of item.enumValues) {
+      result += `\n    ${value.name}`;
+      if (value.isDeprecated) {
+        result += ` @deprecated`;
+        if (value.deprecationReason) {
+          result += ` (${value.deprecationReason})`;
+        }
+      }
+    }
+  }
   // For regular object types, use fields
   else if (item.fields && item.fields.length > 0) {
     result += "\n  Fields:";

--- a/src/tools/shopify-graphql-validation.test.ts
+++ b/src/tools/shopify-graphql-validation.test.ts
@@ -1,0 +1,255 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import {
+  validateGraphQL,
+  formatValidationErrors,
+} from "./shopify-graphql-validation.js";
+import { GraphQLError } from "graphql";
+import * as adminSchema from "./shopify-admin-schema.js";
+
+// Mock the schema loading function
+vi.mock("./shopify-admin-schema.js", () => {
+  return {
+    SCHEMA_FILE_PATH: "mock-path",
+    loadSchemaContent: vi.fn(),
+  };
+});
+
+// Mock the graphql module
+vi.mock("graphql", async () => {
+  const actual = await vi.importActual("graphql");
+  return {
+    ...actual,
+    buildClientSchema: vi.fn(),
+    parse: vi.fn(),
+    validate: vi.fn(),
+  };
+});
+
+import { buildClientSchema, parse, validate } from "graphql";
+
+describe("GraphQL validation", () => {
+  // Sample schema with basic types for testing
+  const mockSchema = JSON.stringify({
+    data: {
+      __schema: {
+        queryType: {
+          name: "QueryRoot",
+        },
+        types: [
+          {
+            kind: "OBJECT",
+            name: "QueryRoot",
+            fields: [
+              {
+                name: "product",
+                args: [
+                  {
+                    name: "id",
+                    type: {
+                      kind: "NON_NULL",
+                      ofType: {
+                        kind: "SCALAR",
+                        name: "ID",
+                      },
+                    },
+                  },
+                ],
+                type: {
+                  kind: "OBJECT",
+                  name: "Product",
+                },
+              },
+            ],
+          },
+          {
+            kind: "OBJECT",
+            name: "Product",
+            fields: [
+              {
+                name: "id",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "ID",
+                  },
+                },
+              },
+              {
+                name: "title",
+                type: {
+                  kind: "SCALAR",
+                  name: "String",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  const mockSchemaObject = {};
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Set up mocks
+    vi.mocked(adminSchema.loadSchemaContent).mockResolvedValue(mockSchema);
+    vi.mocked(buildClientSchema).mockReturnValue(mockSchemaObject as any);
+    vi.mocked(parse).mockReturnValue({} as any);
+
+    // Default to no validation errors
+    vi.mocked(validate).mockReturnValue([]);
+  });
+
+  test("validates a correct GraphQL query", async () => {
+    const validQuery = `
+      query GetProduct {
+        product(id: "gid://shopify/Product/123") {
+          id
+          title
+        }
+      }
+    `;
+
+    const result = await validateGraphQL(validQuery);
+
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toBeUndefined();
+
+    // Verify the right functions were called
+    expect(adminSchema.loadSchemaContent).toHaveBeenCalledWith("mock-path");
+    expect(buildClientSchema).toHaveBeenCalled();
+    expect(parse).toHaveBeenCalledWith(validQuery);
+    expect(validate).toHaveBeenCalled();
+  });
+
+  test("reports errors for invalid fields", async () => {
+    const invalidQuery = `
+      query GetProduct {
+        product(id: "gid://shopify/Product/123") {
+          id
+          title
+          nonExistentField
+        }
+      }
+    `;
+
+    // Mock validation errors
+    const mockError = new GraphQLError(
+      'Cannot query field "nonExistentField" on type "Product"',
+    );
+    vi.mocked(validate).mockReturnValue([mockError]);
+
+    const result = await validateGraphQL(invalidQuery);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toBe(1);
+    expect(result.errors?.[0].message).toMatch(
+      /Cannot query field "nonExistentField"/,
+    );
+  });
+
+  test("reports errors for missing required arguments", async () => {
+    const invalidQuery = `
+      query GetProduct {
+        product {
+          id
+          title
+        }
+      }
+    `;
+
+    // Mock validation errors
+    const mockError = new GraphQLError(
+      'Field "product" argument "id" of type "ID!" is required',
+    );
+    vi.mocked(validate).mockReturnValue([mockError]);
+
+    const result = await validateGraphQL(invalidQuery);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toBe(1);
+    expect(result.errors?.[0].message).toMatch(
+      /Field "product" argument "id" of type "ID!" is required/,
+    );
+  });
+
+  test("handles syntax errors in GraphQL", async () => {
+    const invalidSyntax = `
+      query GetProduct {
+        product(id: "gid://shopify/Product/123") {
+          id
+          title
+        // Missing closing brace
+    `;
+
+    // Mock parse to throw a syntax error
+    vi.mocked(parse).mockImplementation(() => {
+      throw new GraphQLError("Syntax Error: Expected '}', found <EOF>");
+    });
+
+    const result = await validateGraphQL(invalidSyntax);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toBe(1);
+    expect(result.errors?.[0].message).toMatch(
+      /GraphQL validation error: Syntax Error/,
+    );
+  });
+
+  test("handles schema loading errors", async () => {
+    // Mock schema loading failure
+    vi.mocked(adminSchema.loadSchemaContent).mockRejectedValue(
+      new Error("Schema not found"),
+    );
+
+    const query = `query { product(id: "123") { title } }`;
+
+    const result = await validateGraphQL(query);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0].message).toMatch(
+      /GraphQL validation error: Schema not found/,
+    );
+  });
+});
+
+describe("formatValidationErrors", () => {
+  test("formats errors with locations", () => {
+    // Create errors with locations manually
+    const error1 = new GraphQLError("Field does not exist");
+    const error2 = new GraphQLError("Invalid argument");
+
+    // Add locations manually to match the interface
+    Object.defineProperty(error1, "locations", {
+      value: [{ line: 3, column: 5 }],
+    });
+
+    Object.defineProperty(error2, "locations", {
+      value: [{ line: 10, column: 12 }],
+    });
+
+    const formatted = formatValidationErrors([error1, error2]);
+
+    expect(formatted).toContain("1. Field does not exist (Line 3, Column 5)");
+    expect(formatted).toContain("2. Invalid argument (Line 10, Column 12)");
+  });
+
+  test("formats errors without locations", () => {
+    const errors = [
+      new GraphQLError("Parser error"),
+      new GraphQLError("Validation error"),
+    ];
+
+    const formatted = formatValidationErrors(errors);
+
+    expect(formatted).toContain("1. Parser error");
+    expect(formatted).toContain("2. Validation error");
+  });
+});

--- a/src/tools/shopify-graphql-validation.ts
+++ b/src/tools/shopify-graphql-validation.ts
@@ -1,0 +1,78 @@
+import { buildClientSchema, validate, parse, GraphQLError } from "graphql";
+import { loadSchemaContent } from "./shopify-admin-schema.js";
+import { SCHEMA_FILE_PATH } from "./shopify-admin-schema.js";
+
+/**
+ * Interface for GraphQL validation result
+ */
+export interface ValidationResult {
+  isValid: boolean;
+  errors?: readonly GraphQLError[];
+}
+
+/**
+ * Validates GraphQL code against the local Shopify Admin GraphQL schema
+ * @param code The GraphQL code to validate
+ * @returns Promise resolving to a ValidationResult object containing validation status and any errors
+ */
+export async function validateGraphQL(code: string): Promise<ValidationResult> {
+  try {
+    // Load schema content from the local schema file
+    const schemaContent = await loadSchemaContent(SCHEMA_FILE_PATH);
+
+    // Parse the schema content
+    const schemaJson = JSON.parse(schemaContent);
+
+    // Build a GraphQL schema from the JSON
+    const schema = buildClientSchema(schemaJson.data);
+
+    // Parse the GraphQL code into an AST
+    const documentAST = parse(code);
+
+    // Validate the document against the schema
+    const validationErrors = validate(schema, documentAST);
+
+    // Return validation result
+    return {
+      isValid: validationErrors.length === 0,
+      errors: validationErrors.length > 0 ? validationErrors : undefined,
+    };
+  } catch (error) {
+    // Handle parsing or other errors
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Create a GraphQL error to maintain consistent error format
+    const graphqlError = new GraphQLError(
+      `GraphQL validation error: ${errorMessage}`,
+      { originalError: error instanceof Error ? error : undefined },
+    );
+
+    return {
+      isValid: false,
+      errors: [graphqlError],
+    };
+  }
+}
+
+/**
+ * Format validation errors into a human-readable string
+ * @param errors Array of GraphQL errors
+ * @returns Formatted error message string
+ */
+export function formatValidationErrors(
+  errors: readonly GraphQLError[],
+): string {
+  return errors
+    .map((error, index) => {
+      let message = `${index + 1}. ${error.message}`;
+
+      // Add location information if available
+      if (error.locations && error.locations.length > 0) {
+        const location = error.locations[0];
+        message += ` (Line ${location.line}, Column ${location.column})`;
+      }
+
+      return message;
+    })
+    .join("\n");
+}


### PR DESCRIPTION
I've added a `validate_graphql` tool that can be used by agents to make sure that generated graphql is valid.
The validation is done locally.

I've also improved the description of various tools.