### PR TITLE
better composition for validation functions/tool

### DIFF
--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -385,10 +385,10 @@ describe("validate_admin_api_codeblocks tool behavior", () => {
     // Verify the response
     expect(result.content[0].type).toBe("text");
     const responseText = result.content[0].text;
-    expect(responseText).toContain("✅ VALID");
-    expect(responseText).toContain("**Total Code Blocks:** 2");
-    expect(responseText).toContain("Successfully validated GraphQL query");
-    expect(responseText).toContain("No GraphQL operation found");
+    expect(responseText).toContain("## Detailed Results");
+    expect(responseText).toContain("**Status:** ✅ SUCCESS");
+    expect(responseText).toContain("Valid GraphQL query");
+    expect(responseText).toContain("Valid GraphQL mutation");
   });
 
   test("handles validation failures correctly", async () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -195,7 +195,18 @@ export async function shopifyTools(server: McpServer): Promise<void> {
         ),
     },
     async ({ codeblocks, conversationId }) => {
-      const validationResult = await validateAdminGraphQLCodeblocks(codeblocks);
+      // Ensure all codeblocks are properly formatted
+      const formattedCodeblocks = codeblocks.map((block) => {
+        // If block is already wrapped in markdown, use as-is
+        if (block.trim().startsWith("```")) {
+          return block;
+        }
+        // Otherwise, wrap in graphql markdown block
+        return `\`\`\`graphql\n${block}\n\`\`\``;
+      });
+
+      const validationResult =
+        await validateAdminGraphQLCodeblocks(formattedCodeblocks);
       const responseText = validationSummary(validationResult);
 
       recordUsage(

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -205,8 +205,9 @@ export async function shopifyTools(server: McpServer): Promise<void> {
         return `\`\`\`graphql\n${block}\n\`\`\``;
       });
 
-      const validationResult =
-        await validateAdminGraphQLCodeblocks(formattedCodeblocks);
+      const validationResult = await validateAdminGraphQLCodeblocks(
+        formattedCodeblocks.join("\n\n"),
+      );
       const responseText = validationSummary(validationResult);
 
       recordUsage(

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export interface ValidationResponse {
   resultDetail: string;
 }
 
-export interface ValidationToolResult {
+export interface ValidationFunctionResult {
   /**
    * Overall validation status - true only if all checks passed or were skipped
    */

--- a/src/validations/adminGraphql.test.ts
+++ b/src/validations/adminGraphql.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import validateAdminGraphQLCodeblocks from "./adminGraphql.js";
+import validateGraphQLOperation from "./graphqlSchema.js";
+import { ValidationResult } from "../types.js";
+
+// Mock the graphqlSchema module
+vi.mock("./graphqlSchema.js", () => ({
+  default: vi.fn(),
+}));
+
+describe("validateAdminGraphQLCodeblocks", () => {
+  const mockValidateGraphQLOperation = vi.mocked(validateGraphQLOperation);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should validate multiple codeblocks in parallel", async () => {
+    mockValidateGraphQLOperation
+      .mockResolvedValueOnce({
+        result: ValidationResult.SUCCESS,
+        resultDetail: "Valid GraphQL query",
+      })
+      .mockResolvedValueOnce({
+        result: ValidationResult.SUCCESS,
+        resultDetail: "Valid GraphQL mutation",
+      });
+
+    const codeblocks = [
+      "```graphql\nquery { products { id } }\n```",
+      "```graphql\nmutation { productCreate(input: {}) { product { id } } }\n```",
+    ];
+
+    const result = await validateAdminGraphQLCodeblocks(codeblocks);
+
+    expect(mockValidateGraphQLOperation).toHaveBeenCalledTimes(2);
+    expect(mockValidateGraphQLOperation).toHaveBeenNthCalledWith(
+      1,
+      codeblocks[0],
+      "admin",
+    );
+    expect(mockValidateGraphQLOperation).toHaveBeenNthCalledWith(
+      2,
+      codeblocks[1],
+      "admin",
+    );
+
+    expect(result).toEqual({
+      valid: true,
+      detailedChecks: [
+        {
+          result: ValidationResult.SUCCESS,
+          resultDetail: "Valid GraphQL query",
+        },
+        {
+          result: ValidationResult.SUCCESS,
+          resultDetail: "Valid GraphQL mutation",
+        },
+      ],
+    });
+  });
+
+  it("should return valid: true only when all validations succeed", async () => {
+    mockValidateGraphQLOperation
+      .mockResolvedValueOnce({
+        result: ValidationResult.SUCCESS,
+        resultDetail: "Valid GraphQL",
+      })
+      .mockResolvedValueOnce({
+        result: ValidationResult.SUCCESS,
+        resultDetail: "Valid GraphQL",
+      });
+
+    const result = await validateAdminGraphQLCodeblocks([
+      "```graphql\nquery { products { id } }\n```",
+      "```graphql\nquery { shop { name } }\n```",
+    ]);
+
+    expect(result.valid).toBe(true);
+    expect(result.detailedChecks).toHaveLength(2);
+  });
+
+  it("should return valid: false when any validation fails", async () => {
+    mockValidateGraphQLOperation
+      .mockResolvedValueOnce({
+        result: ValidationResult.SUCCESS,
+        resultDetail: "Valid GraphQL",
+      })
+      .mockResolvedValueOnce({
+        result: ValidationResult.FAILED,
+        resultDetail: "Invalid GraphQL",
+      });
+
+    const result = await validateAdminGraphQLCodeblocks([
+      "```graphql\nquery { products { id } }\n```",
+      "```graphql\nquery { invalidField }\n```",
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.detailedChecks).toHaveLength(2);
+    expect(result.detailedChecks[0].result).toBe(ValidationResult.SUCCESS);
+    expect(result.detailedChecks[1].result).toBe(ValidationResult.FAILED);
+  });
+
+  it("should return valid: false when any validation is skipped", async () => {
+    mockValidateGraphQLOperation
+      .mockResolvedValueOnce({
+        result: ValidationResult.SUCCESS,
+        resultDetail: "Valid GraphQL",
+      })
+      .mockResolvedValueOnce({
+        result: ValidationResult.SKIPPED,
+        resultDetail: "Skipped empty codeblock",
+      });
+
+    const result = await validateAdminGraphQLCodeblocks([
+      "```graphql\nquery { products { id } }\n```",
+      "```graphql\n\n```",
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.detailedChecks).toHaveLength(2);
+    expect(result.detailedChecks[0].result).toBe(ValidationResult.SUCCESS);
+    expect(result.detailedChecks[1].result).toBe(ValidationResult.SKIPPED);
+  });
+
+  it("should handle empty codeblocks array", async () => {
+    const result = await validateAdminGraphQLCodeblocks([]);
+
+    expect(mockValidateGraphQLOperation).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      valid: true,
+      detailedChecks: [],
+    });
+  });
+
+  it("should handle single codeblock", async () => {
+    mockValidateGraphQLOperation.mockResolvedValueOnce({
+      result: ValidationResult.SUCCESS,
+      resultDetail: "Valid GraphQL",
+    });
+
+    const result = await validateAdminGraphQLCodeblocks([
+      "```graphql\nquery { products { id } }\n```",
+    ]);
+
+    expect(mockValidateGraphQLOperation).toHaveBeenCalledTimes(1);
+    expect(result.valid).toBe(true);
+    expect(result.detailedChecks).toHaveLength(1);
+  });
+
+  it("should propagate validation errors", async () => {
+    mockValidateGraphQLOperation.mockRejectedValueOnce(
+      new Error("Schema loading failed"),
+    );
+
+    await expect(
+      validateAdminGraphQLCodeblocks([
+        "```graphql\nquery { products { id } }\n```",
+      ]),
+    ).rejects.toThrow("Schema loading failed");
+  });
+});

--- a/src/validations/adminGraphql.ts
+++ b/src/validations/adminGraphql.ts
@@ -1,0 +1,25 @@
+import validateGraphQLOperation from "./graphqlSchema.js";
+import { ValidationFunctionResult, ValidationResult } from "../types.js";
+import { aggregateValidationResults } from "./validationUtils.js";
+
+/**
+ * Validates multiple GraphQL Admin API codeblocks
+ * @param codeblocks - Array of markdown code blocks containing GraphQL operations to validate
+ * @returns ValidationToolResult with overall status and detailed checks
+ */
+export default async function validateAdminGraphQLCodeblocks(
+  codeblocks: string[],
+): Promise<ValidationFunctionResult> {
+  const validationResponses = await Promise.all(
+    codeblocks.map(async (block) => {
+      return await validateGraphQLOperation(block, "admin");
+    }),
+  );
+
+  return {
+    valid: validationResponses.every(
+      (response) => response.result === ValidationResult.SUCCESS,
+    ),
+    detailedChecks: validationResponses,
+  };
+}

--- a/src/validations/adminGraphql.ts
+++ b/src/validations/adminGraphql.ts
@@ -1,6 +1,5 @@
 import validateGraphQLOperation from "./graphqlSchema.js";
 import { ValidationFunctionResult, ValidationResult } from "../types.js";
-import { aggregateValidationResults } from "./validationUtils.js";
 
 /**
  * Validates multiple GraphQL Admin API codeblocks

--- a/src/validations/adminGraphql.ts
+++ b/src/validations/adminGraphql.ts
@@ -1,24 +1,14 @@
 import validateGraphQLOperation from "./graphqlSchema.js";
-import { ValidationFunctionResult, ValidationResult } from "../types.js";
+import { ValidationFunctionResult } from "../types.js";
 
 /**
- * Validates multiple GraphQL Admin API codeblocks
- * @param codeblocks - Array of markdown code blocks containing GraphQL operations to validate
- * @returns ValidationToolResult with overall status and detailed checks
+ * Validates GraphQL Admin API operations from a markdown response
+ * @param markdownResponse - Markdown response containing GraphQL codeblocks to validate
+ * @returns ValidationFunctionResult with overall status and detailed checks
  */
 export default async function validateAdminGraphQLCodeblocks(
-  codeblocks: string[],
+  markdownResponse: string,
 ): Promise<ValidationFunctionResult> {
-  const validationResponses = await Promise.all(
-    codeblocks.map(async (block) => {
-      return await validateGraphQLOperation(block, "admin");
-    }),
-  );
-
-  return {
-    valid: validationResponses.every(
-      (response) => response.result === ValidationResult.SUCCESS,
-    ),
-    detailedChecks: validationResponses,
-  };
+  // Insert more validation requirements here...
+  return await validateGraphQLOperation(markdownResponse, "admin");
 }

--- a/src/validations/graphqlSchema.test.ts
+++ b/src/validations/graphqlSchema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { validateGraphQLOperation } from "./graphqlSchema.js";
+import validateGraphQLOperation from "./graphqlSchema.js";
 import { ValidationResult } from "../types.js";
 import * as shopifyAdminSchema from "../tools/shopify-admin-schema.js";
 
@@ -397,7 +397,7 @@ query {
         expect(result.detailedChecks[0].resultDetail).toContain(
           "Successfully validated GraphQL",
         );
-        expect(result.detailedChecks[0].resultDetail).toContain("admin schema");
+        expect(result.detailedChecks[0].resultDetail).toContain("Admin API schema");
       } else if (result.detailedChecks[0].result === ValidationResult.FAILED) {
         // Could be schema loading/conversion error, not syntax or schema name error
         expect(result.detailedChecks[0].resultDetail).not.toContain(
@@ -435,7 +435,7 @@ query {
         expect(result.detailedChecks[0].resultDetail).toContain(
           "Successfully validated GraphQL",
         );
-        expect(result.detailedChecks[0].resultDetail).toContain("admin schema");
+        expect(result.detailedChecks[0].resultDetail).toContain("Admin API schema");
       } else if (result.detailedChecks[0].result === ValidationResult.FAILED) {
         // Could be schema loading/conversion error, not syntax error
         expect(result.detailedChecks[0].resultDetail).not.toContain(
@@ -519,7 +519,7 @@ query {
       expect(result.detailedChecks[0].resultDetail).toContain(
         "Successfully validated GraphQL",
       );
-      expect(result.detailedChecks[0].resultDetail).toContain("admin schema");
+      expect(result.detailedChecks[0].resultDetail).toContain("Admin API schema");
     });
   });
 

--- a/src/validations/graphqlSchema.ts
+++ b/src/validations/graphqlSchema.ts
@@ -174,9 +174,15 @@ function extractCodeblocksWithRegex(
 function isLikelyGraphQLOperation(content: string): boolean {
   const graphqlKeywords = /^\s*(?:query|mutation|subscription|fragment)\s+/i;
   const graphqlSyntax =
-    /(?:query|mutation|subscription|fragment)\s*(?:\w+\s*)?\{|^\s*\{/;
+    /(?:query|mutation|subscription|fragment)\s*(?:\w+\s*)?\{/;
 
-  return graphqlKeywords.test(content) || graphqlSyntax.test(content);
+  const anonymousGraphQL = /^\s*\{\s*\w+\s*(?:\([^)]*\))?\s*\{/;
+
+  return (
+    graphqlKeywords.test(content) ||
+    graphqlSyntax.test(content) ||
+    anonymousGraphQL.test(content)
+  );
 }
 
 async function loadAndBuildGraphQLSchema(schemaName: SupportedSchemaName) {

--- a/src/validations/validationUtils.test.ts
+++ b/src/validations/validationUtils.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatValidationResults,
+  validationSummary,
+} from "./validationUtils.js";
+import { ValidationResult, ValidationFunctionResult } from "../types.js";
+
+describe("validationUtils", () => {
+  describe("formatValidationResults", () => {
+    it("should format validation results with all successful checks", () => {
+      const input: ValidationFunctionResult = {
+        valid: true,
+        detailedChecks: [
+          {
+            result: ValidationResult.SUCCESS,
+            resultDetail: "Valid GraphQL query",
+          },
+          {
+            result: ValidationResult.SUCCESS,
+            resultDetail: "Valid GraphQL mutation",
+          },
+        ],
+      };
+
+      const result = formatValidationResults(input);
+
+      expect(result).toEqual({
+        valid: true,
+        detailedChecks: input.detailedChecks,
+      });
+    });
+
+    it("should format validation results with failed checks", () => {
+      const input: ValidationFunctionResult = {
+        valid: false,
+        detailedChecks: [
+          {
+            result: ValidationResult.SUCCESS,
+            resultDetail: "Valid GraphQL query",
+          },
+          {
+            result: ValidationResult.FAILED,
+            resultDetail: "Invalid GraphQL operation",
+          },
+        ],
+      };
+
+      const result = formatValidationResults(input);
+
+      expect(result).toEqual({
+        valid: false,
+        detailedChecks: input.detailedChecks,
+      });
+    });
+
+    it("should format validation results with skipped checks", () => {
+      const input: ValidationFunctionResult = {
+        valid: false,
+        detailedChecks: [
+          {
+            result: ValidationResult.SKIPPED,
+            resultDetail: "Skipped empty codeblock",
+          },
+        ],
+      };
+
+      const result = formatValidationResults(input);
+
+      expect(result).toEqual({
+        valid: false,
+        detailedChecks: input.detailedChecks,
+      });
+    });
+
+    it("should handle empty detailedChecks array", () => {
+      const input: ValidationFunctionResult = {
+        valid: true,
+        detailedChecks: [],
+      };
+
+      const result = formatValidationResults(input);
+
+      expect(result).toEqual({
+        valid: false, // overallStatus returns SKIPPED when no checks exist
+        detailedChecks: [],
+      });
+    });
+  });
+
+  describe("validationSummary", () => {
+    it("should generate summary with success icons", () => {
+      const input: ValidationFunctionResult = {
+        valid: true,
+        detailedChecks: [
+          {
+            result: ValidationResult.SUCCESS,
+            resultDetail: "Valid GraphQL query",
+          },
+          {
+            result: ValidationResult.SUCCESS,
+            resultDetail: "Valid GraphQL mutation",
+          },
+        ],
+      };
+
+      const result = validationSummary(input);
+
+      expect(result).toContain("## Detailed Results");
+      expect(result).toContain("### Validation 1");
+      expect(result).toContain("**Status:** ✅ SUCCESS");
+      expect(result).toContain("**Details:** Valid GraphQL query");
+      expect(result).toContain("### Validation 2");
+      expect(result).toContain("**Details:** Valid GraphQL mutation");
+    });
+
+    it("should generate summary with failure icons", () => {
+      const input: ValidationFunctionResult = {
+        valid: false,
+        detailedChecks: [
+          {
+            result: ValidationResult.FAILED,
+            resultDetail: "Invalid GraphQL operation",
+          },
+        ],
+      };
+
+      const result = validationSummary(input);
+
+      expect(result).toContain("## Detailed Results");
+      expect(result).toContain("### Validation 1");
+      expect(result).toContain("**Status:** ❌ FAILED");
+      expect(result).toContain("**Details:** Invalid GraphQL operation");
+    });
+
+    it("should generate summary with skipped icons", () => {
+      const input: ValidationFunctionResult = {
+        valid: false,
+        detailedChecks: [
+          {
+            result: ValidationResult.SKIPPED,
+            resultDetail: "Skipped empty codeblock",
+          },
+        ],
+      };
+
+      const result = validationSummary(input);
+
+      expect(result).toContain("## Detailed Results");
+      expect(result).toContain("### Validation 1");
+      expect(result).toContain("**Status:** ⏭️ SKIPPED");
+      expect(result).toContain("**Details:** Skipped empty codeblock");
+    });
+
+    it("should generate summary with mixed validation results", () => {
+      const input: ValidationFunctionResult = {
+        valid: false,
+        detailedChecks: [
+          {
+            result: ValidationResult.SUCCESS,
+            resultDetail: "Valid GraphQL query",
+          },
+          {
+            result: ValidationResult.FAILED,
+            resultDetail: "Invalid GraphQL operation",
+          },
+          {
+            result: ValidationResult.SKIPPED,
+            resultDetail: "Skipped empty codeblock",
+          },
+        ],
+      };
+
+      const result = validationSummary(input);
+
+      expect(result).toContain("## Detailed Results");
+      expect(result).toContain("### Validation 1");
+      expect(result).toContain("**Status:** ✅ SUCCESS");
+      expect(result).toContain("### Validation 2");
+      expect(result).toContain("**Status:** ❌ FAILED");
+      expect(result).toContain("### Validation 3");
+      expect(result).toContain("**Status:** ⏭️ SKIPPED");
+    });
+
+    it("should handle empty detailedChecks array", () => {
+      const input: ValidationFunctionResult = {
+        valid: true,
+        detailedChecks: [],
+      };
+
+      const result = validationSummary(input);
+
+      expect(result).toContain("## Detailed Results");
+      expect(result).not.toContain("### Validation");
+    });
+
+    it("should properly number validation results", () => {
+      const input: ValidationFunctionResult = {
+        valid: true,
+        detailedChecks: [
+          {
+            result: ValidationResult.SUCCESS,
+            resultDetail: "First validation",
+          },
+          {
+            result: ValidationResult.SUCCESS,
+            resultDetail: "Second validation",
+          },
+          {
+            result: ValidationResult.SUCCESS,
+            resultDetail: "Third validation",
+          },
+        ],
+      };
+
+      const result = validationSummary(input);
+
+      expect(result).toContain("### Validation 1");
+      expect(result).toContain("### Validation 2");
+      expect(result).toContain("### Validation 3");
+      expect(result).toContain("**Details:** First validation");
+      expect(result).toContain("**Details:** Second validation");
+      expect(result).toContain("**Details:** Third validation");
+    });
+  });
+});

--- a/src/validations/validationUtils.ts
+++ b/src/validations/validationUtils.ts
@@ -1,0 +1,52 @@
+import { ValidationResult, ValidationFunctionResult } from "../types.js";
+
+/**
+ * Formats a ValidationFunctionResult into a readable markdown response
+ * @param results - The validation results to format
+ * @returns Formatted ValidationFunctionResult with overall status and detailed checks
+ */
+export function formatValidationResults(
+  results: ValidationFunctionResult,
+): ValidationFunctionResult {
+  return {
+    valid: overallStatus(results) === ValidationResult.SUCCESS,
+    detailedChecks: results.detailedChecks,
+  };
+}
+
+export function validationSummary(results: ValidationFunctionResult): string {
+  let detailedResults = `## Detailed Results\n\n`;
+  results.detailedChecks.forEach((check, index) => {
+    const statusIcon =
+      check.result === ValidationResult.SUCCESS
+        ? "✅"
+        : check.result === ValidationResult.SKIPPED
+          ? "⏭️"
+          : "❌";
+    detailedResults += `### Validation ${index + 1}\n`;
+    detailedResults += `**Status:** ${statusIcon} ${check.result.toUpperCase()}\n`;
+    detailedResults += `**Details:** ${check.resultDetail}\n\n`;
+  });
+
+  return detailedResults;
+}
+
+function overallStatus(results: ValidationFunctionResult): ValidationResult {
+  const successCount = results.detailedChecks.filter(
+    (check) => check.result === ValidationResult.SUCCESS,
+  ).length;
+  const failureCount = results.detailedChecks.filter(
+    (check) => check.result === ValidationResult.FAILED,
+  ).length;
+  const skippedCount = results.detailedChecks.filter(
+    (check) => check.result === ValidationResult.SKIPPED,
+  ).length;
+
+  if (failureCount > 0) {
+    return ValidationResult.FAILED;
+  } else if (successCount > 0) {
+    return ValidationResult.SUCCESS;
+  } else {
+    return ValidationResult.SKIPPED;
+  }
+}


### PR DESCRIPTION
Validation function results will be a key export of this server. Outside of MCP tools, we will want to use that same logic when detecting human error in the API docs as well as with our promptfoo evals.

This PR introduces a new pattern that all new validation functions/tools will follow: MCP tools will be thin wrappers around validation functions for each API we support. 
