### PR TITLE
Add support to Liquid MCP query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ If you want Cursor or Claude Desktop to surface Polaris Web Components documenta
 }
 ```
 
+<!--
+### Opt-in Liquid support (experimental)
+
+If you want Cursor or Claude Desktop to surface Liquid documentation, include an `env` block with the `LIQUID_MCP` flag in your MCP server configuration:
+
+```json
+{
+  "mcpServers": {
+    "shopify-dev-mcp": {
+      "command": "npx",
+      "args": ["-y", "@shopify/dev-mcp@latest"],
+      "env": {
+        "LIQUID_MCP": "true"
+      }
+    }
+  }
+}
+```
+-->
+
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=shopify-dev-mcp&config=eyJjb21tYW5kIjoibnB4IC15IEBzaG9waWZ5L2Rldi1tY3BAbGF0ZXN0IiwiZW52Ijp7IlBPTEFSSVNfVU5JRklFRCI6InRydWUifX0%3D)
 
 ## Available tools

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,6 +15,9 @@ import { searchShopifyAdminSchema } from "./shopifyAdminSchema.js";
 const polarisUnifiedEnabled =
   process.env.POLARIS_UNIFIED === "true" || process.env.POLARIS_UNIFIED === "1";
 
+const liquidMcpEnabled =
+  process.env.LIQUID_MCP === "true" || process.env.LIQUID_MCP === "1";
+
 /**
  * Helper function to make requests to the Shopify dev server
  * @param path The API path (e.g., "/mcp/search", "/mcp/getting_started")
@@ -48,6 +51,14 @@ async function shopifyDevFetch(
     !url.searchParams.has("polaris_unified")
   ) {
     url.searchParams.append("polaris_unified", "true");
+  }
+
+  if (
+    liquidMcpEnabled &&
+    path.startsWith("/mcp/getting_started_apis") &&
+    !url.searchParams.has("liquid_mcp")
+  ) {
+    url.searchParams.append("liquid_mcp", "true");
   }
 
   console.error(


### PR DESCRIPTION
Introduce support for the `LIQUID_MCP` configuration. Right now, this is a no-op and doesn't affect users, so I'm not including a changeset or exposing the flag in the `README.md`.