### PR TITLE
Run liquid check on files LLM touched

### DIFF
--- a/src/validations/theme.ts
+++ b/src/validations/theme.ts
@@ -1,16 +1,18 @@
-import { themeCheckRun } from "@shopify/theme-check-node";
+import { Offense, themeCheckRun } from "@shopify/theme-check-node";
 import { access } from "fs/promises";
-import { join } from "path";
+import { join, normalize } from "path";
 import { ValidationResponse, ValidationResult } from "../types.js";
 
 /**
  * Validates Shopify Theme
  * @param absoluteThemePath - The path to the theme directory
+ * @param filesCreatedOrUpdated - An array of relative file paths that was generated or updated by the LLM. The file paths should be relative to the theme directory.
  * @returns ValidationResponse containing the success of running theme-check for the whole theme
  */
 export default async function validateTheme(
   absoluteThemePath: string,
-): Promise<ValidationResponse> {
+  filesCreatedOrUpdated: string[],
+): Promise<ValidationResponse[]> {
   try {
     let configPath: string | undefined = join(
       absoluteThemePath,
@@ -29,24 +31,54 @@ export default async function validateTheme(
       (message) => console.error(message),
     );
 
-    if (results.offenses.length > 0) {
-      const formattedOffenses = results.offenses
-        .map((offense) => `${offense.uri}: ${offense.message}`)
-        .join("\n");
-      return {
-        result: ValidationResult.FAILED,
-        resultDetail: `Theme at ${absoluteThemePath} failed to validate:\n\n${formattedOffenses}`,
-      };
+    const groupedOffensesByFileUri = groupOffensesByFileUri(results.offenses);
+
+    const responses: ValidationResponse[] = [];
+
+    for (const relativeFilePath of filesCreatedOrUpdated) {
+      const uri = Object.keys(groupedOffensesByFileUri).find((uri) =>
+        normalize(uri).endsWith(normalize(relativeFilePath)),
+      );
+      if (uri) {
+        responses.push({
+          result: ValidationResult.FAILED,
+          resultDetail: `Theme file ${relativeFilePath} failed to validate:\n\n${groupedOffensesByFileUri[uri].join("\n")}`,
+        });
+      } else {
+        responses.push({
+          result: ValidationResult.SUCCESS,
+          resultDetail: `Theme file ${relativeFilePath} passed all checks from Shopify's Theme Check.`,
+        });
+      }
     }
 
-    return {
-      result: ValidationResult.SUCCESS,
-      resultDetail: `Theme at ${absoluteThemePath} passed all checks from Shopify's Theme Check.`,
-    };
+    return responses;
   } catch (error) {
-    return {
+    return filesCreatedOrUpdated.map((filePath) => ({
       result: ValidationResult.FAILED,
-      resultDetail: `Validation error: Could not validate ${absoluteThemePath}. Details: ${error instanceof Error ? error.message : String(error)}`,
-    };
+      resultDetail: `Validation error: Could not validate ${filePath}. Details: ${error instanceof Error ? error.message : String(error)}`,
+    }));
   }
+}
+
+export function groupOffensesByFileUri(offenses: Offense[]) {
+  return offenses.reduce(
+    (acc, o) => {
+      let formattedMessage = `ERROR: ${o.message}`;
+
+      if (o.suggest && o.suggest.length > 0) {
+        formattedMessage += `; SUGGESTED FIXES: ${o.suggest.map((s) => s.message).join("OR ")}.`;
+      }
+
+      const uri = o.uri;
+
+      if (acc[uri]) {
+        acc[uri].push(formattedMessage);
+      } else {
+        acc[uri] = [formattedMessage];
+      }
+      return acc;
+    },
+    {} as Record<string, string[]>,
+  );
 }

--- a/src/validations/themeCodeBlock.test.ts
+++ b/src/validations/themeCodeBlock.test.ts
@@ -147,7 +147,7 @@ describe("validateThemeCodeblocks", () => {
     expect(result).toContainEqual({
       result: ValidationResult.FAILED,
       resultDetail:
-        "Theme codeblock test.liquid has the following offenses from using Shopify's Theme Check:\n\nERROR: The variable 'some_var' is assigned but not used; SUGGESTED FIXES: Remove the unused variable 'some_var'",
+        "Theme codeblock test.liquid has the following offenses from using Shopify's Theme Check:\n\nERROR: The variable 'some_var' is assigned but not used; SUGGESTED FIXES: Remove the unused variable 'some_var'.",
     });
   });
 
@@ -219,7 +219,7 @@ ERROR: Schema name '${schemaName}' is too long (max 25 characters)`,
       result: ValidationResult.FAILED,
       resultDetail: `Theme codeblock test.liquid has the following offenses from using Shopify's Theme Check:
 
-ERROR: Missing required argument 'param' in render tag for snippet 'example-snippet'.; SUGGESTED FIXES: Add required argument 'param'`,
+ERROR: Missing required argument 'param' in render tag for snippet 'example-snippet'.; SUGGESTED FIXES: Add required argument 'param'.`,
     });
   });
 });

--- a/src/validations/themeCodeBlock.ts
+++ b/src/validations/themeCodeBlock.ts
@@ -7,7 +7,6 @@ import {
   FileTuple,
   FileType,
   LiquidHtmlNode,
-  Offense,
   path,
   recommended,
   SectionSchema,
@@ -19,6 +18,7 @@ import {
 import { ThemeLiquidDocsManager } from "@shopify/theme-check-docs-updater";
 import { normalize } from "path";
 import { ValidationResponse, ValidationResult } from "../types.js";
+import { groupOffensesByFileUri } from "./theme.js";
 
 type ThemeCodeblock = {
   fileName: string;
@@ -69,7 +69,7 @@ async function validatePartialTheme(
     if (fileUriToOffenses[uri]) {
       validationResults.push({
         result: ValidationResult.FAILED,
-        resultDetail: `Theme codeblock ${name} has the following offenses from using Shopify's Theme Check:\n\n${fileUriToOffenses[uri].join("\n\n")}`,
+        resultDetail: `Theme codeblock ${name} has the following offenses from using Shopify's Theme Check:\n\n${fileUriToOffenses[uri].join("\n")}`,
       });
     } else {
       validationResults.push({
@@ -155,26 +155,6 @@ function createTheme(codeblocks: ThemeCodeblock[]): Theme {
     theme[uri] = codeblock.content;
     return theme;
   }, {} as Theme);
-}
-
-function groupOffensesByFileUri(offenses: Offense[]) {
-  return offenses.reduce(
-    (acc, o) => {
-      let formattedMessage = `ERROR: ${o.message}`;
-
-      if (o.suggest && o.suggest.length > 0) {
-        formattedMessage += `; SUGGESTED FIXES: ${o.suggest.map((s) => s.message).join("OR ")}`;
-      }
-
-      if (acc[o.uri]) {
-        acc[o.uri].push(formattedMessage);
-      } else {
-        acc[o.uri] = [formattedMessage];
-      }
-      return acc;
-    },
-    {} as Record<string, string[]>,
-  );
 }
 
 // We mimic a theme on a file system to be able to run theme checks


### PR DESCRIPTION
- `validate_theme` will now take an input from the LLM to know which files it touched
  - only return failures for files it touched
  - the other theme-check failures will be ignored