### PR TITLE
Remove LIQUID_MCP environment variable usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,26 +84,6 @@ If you want Cursor or Claude Desktop to surface Polaris Web Components documenta
 }
 ```
 
-<!--
-### Opt-in Liquid support (experimental)
-
-If you want Cursor or Claude Desktop to surface Liquid documentation, include an `env` block with the `LIQUID_MCP` flag in your MCP server configuration:
-
-```json
-{
-  "mcpServers": {
-    "shopify-dev-mcp": {
-      "command": "npx",
-      "args": ["-y", "@shopify/dev-mcp@latest"],
-      "env": {
-        "LIQUID_MCP": "true"
-      }
-    }
-  }
-}
-```
--->
-
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=shopify-dev-mcp&config=eyJjb21tYW5kIjoibnB4IC15IEBzaG9waWZ5L2Rldi1tY3BAbGF0ZXN0IiwiZW52Ijp7IlBPTEFSSVNfVU5JRklFRCI6InRydWUifX0%3D)
 
 ## Available tools

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -280,7 +280,6 @@ describe("fetchGettingStartedApis", () => {
     vi.resetModules();
     // Reset environment to clean state
     process.env = { ...originalEnv };
-    delete process.env.LIQUID_MCP;
   });
 
   afterEach(() => {
@@ -306,14 +305,12 @@ describe("fetchGettingStartedApis", () => {
 
     // Verify fetch was called to get the APIs
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining("/mcp/getting_started_apis"),
+      expect.stringContaining("/mcp/getting_started_apis?liquid_mcp=true"),
       expect.any(Object),
     );
   });
 
-  test("adds liquid_mcp query parameter when environment variable is set", async () => {
-    process.env.LIQUID_MCP = "true";
-
+  test("adds liquid_mcp query parameter", async () => {
     const { shopifyTools } = await import("./index.js");
 
     const fetchSpy = vi.spyOn(global, "fetch");
@@ -323,22 +320,6 @@ describe("fetchGettingStartedApis", () => {
 
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining("/mcp/getting_started_apis?liquid_mcp=true"),
-      expect.any(Object),
-    );
-  });
-
-  test("does not add liquid_mcp query parameter when environment variable is false", async () => {
-    process.env.LIQUID_MCP = "false";
-
-    const { shopifyTools } = await import("./index.js");
-
-    const fetchSpy = vi.spyOn(global, "fetch");
-    const mockServer = { tool: vi.fn() };
-
-    await shopifyTools(mockServer as any);
-
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining("/mcp/getting_started_apis"),
       expect.any(Object),
     );
   });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,9 +13,6 @@ import { shopifyDevFetch } from "./shopifyDevFetch.js";
 const polarisUnifiedEnabled =
   process.env.POLARIS_UNIFIED === "true" || process.env.POLARIS_UNIFIED === "1";
 
-const liquidMcpEnabled =
-  process.env.LIQUID_MCP === "true" || process.env.LIQUID_MCP === "1";
-
 const GettingStartedAPISchema = z.object({
   name: z.string(),
   description: z.string(),
@@ -490,7 +487,7 @@ async function fetchGettingStartedApis(): Promise<GettingStartedAPI[]> {
   try {
     const parameters: Record<string, string> = {
       ...(polarisUnifiedEnabled && { polaris_unified: "true" }),
-      ...(liquidMcpEnabled && { liquid_mcp: "true" }),
+      ...{ liquid_mcp: "true" },
     };
 
     const responseText = await shopifyDevFetch("/mcp/getting_started_apis", {
@@ -553,10 +550,6 @@ function formatValidationResult(
 }
 
 function liquidMcpTools(server: McpServer) {
-  if (!liquidMcpEnabled) {
-    return;
-  }
-
   const themeRepositoryDescription = `A theme repository is a directory that MUST contain the following directories: snippets, sections, config, templates. It can optionally contain assets, locales, blocks, layouts.`;
 
   server.tool(


### PR DESCRIPTION
Remove the `LIQUID_MCP` environment variable as the liquid MCP tools will now be available by default.