### PR TITLE
Add LIQUID env flag

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,6 +1,9 @@
 export const polarisUnifiedEnabled =
   process.env.POLARIS_UNIFIED === "true" || process.env.POLARIS_UNIFIED === "1";
 
+export const liquidEnabled =
+  process.env.LIQUID === "true" || process.env.LIQUID === "1";
+
 // LIQUID_VALIDATION_MODE can be "full" or "partial"
 export const liquidMcpValidationMode =
   process.env.LIQUID_VALIDATION_MODE === "partial" ? "partial" : "full";

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -300,12 +300,18 @@ describe("fetchGettingStartedApis", () => {
 
     // Verify fetch was called to get the APIs
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining("/mcp/getting_started_apis?liquid_mcp=true"),
+      expect.stringContaining("/mcp/getting_started_apis"),
       expect.any(Object),
     );
   });
 
   test("adds liquid_mcp query parameter", async () => {
+    vi.doMock("../flags.js", () => ({
+      liquidEnabled: true,
+      polarisUnifiedEnabled: false,
+      liquidMcpValidationMode: "full",
+    }));
+
     const { shopifyTools } = await import("./index.js");
 
     const fetchSpy = vi.spyOn(global, "fetch");

--- a/src/tools/learn_shopify_api/index.ts
+++ b/src/tools/learn_shopify_api/index.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { polarisUnifiedEnabled } from "../../flags.js";
+import { liquidEnabled, polarisUnifiedEnabled } from "../../flags.js";
 import { generateConversationId, recordUsage } from "../../instrumentation.js";
 import { shopifyDevFetch } from "../shopify_dev_fetch/index.js";
 
@@ -19,7 +19,7 @@ async function fetchGettingStartedApis(): Promise<GettingStartedAPI[]> {
   try {
     const parameters: Record<string, string> = {
       ...(polarisUnifiedEnabled && { polaris_unified: "true" }),
-      ...{ liquid_mcp: "true" },
+      ...(liquidEnabled && { liquid_mcp: "true" }),
     };
 
     const responseText = await shopifyDevFetch("/mcp/getting_started_apis", {

--- a/src/tools/liquid_mcp_tools/index.ts
+++ b/src/tools/liquid_mcp_tools/index.ts
@@ -1,13 +1,17 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { liquidMcpValidationMode } from "../../flags.js";
-import { formatValidationResult, withConversationId } from "../index.js";
 import { z } from "zod";
-import validateThemeCodeblocks from "../../validations/themeCodeBlock.js";
+import { liquidEnabled, liquidMcpValidationMode } from "../../flags.js";
 import { recordUsage } from "../../instrumentation.js";
 import { hasFailedValidation } from "../../validations/index.js";
 import validateTheme from "../../validations/theme.js";
+import validateThemeCodeblocks from "../../validations/themeCodeBlock.js";
+import { formatValidationResult, withConversationId } from "../index.js";
 
 export default async function liquidMcpTools(server: McpServer) {
+  if (!liquidEnabled) {
+    return;
+  }
+
   const toolDescription = `This tool validates Liquid codeblocks, Liquid files, and supporting Theme files (e.g. JSON locale files, JSON config files, JSON template files, JavaScript files, CSS files, and SVG files) generated or updated by LLMs to ensure they don't have hallucinated Liquid content, invalid syntax, or incorrect references`;
 
   if (liquidMcpValidationMode === "partial") {


### PR DESCRIPTION
- Make sure we only enable liquid validation tools and fetches liquid content from `/mcp/getting_started_apis` if the env flag is set